### PR TITLE
added validation that skips events for elements disabled after initialization

### DIFF
--- a/custom-form-elements.js
+++ b/custom-form-elements.js
@@ -194,6 +194,7 @@ Example:
 
         mousedown: function(el, e) {
             if (!(e.isTrigger || e.which === 1)) { return; } // Only respond to left mouse clicks
+            if (el.className.indexOf('cfe-disabled') > -1) { return; }  // only respond if element isn't marked as disabled
 
             var input = document.getElementById( el.id.split('cfe-').pop() );
             this.setState(el, (input.checked ? 3 : 1));
@@ -201,6 +202,7 @@ Example:
 
         mouseup: function(el, e) {
             if (!(e.isTrigger || e.which === 1)) { return; } // Only respond to left mouse clicks
+            if (el.className.indexOf('cfe-disabled') > -1) { return; }  // only respond if element isn't marked as disabled
 
             var self = this;
             var input = document.getElementById( el.id.split('cfe-').pop() );


### PR DESCRIPTION
When an element is marked as disabled ('.cfe-disabled') after initialization, the bindings aren't skipped unless .repaint() is run.  When using a form with many (50+) elements, repaint() causes a heavy delay in Chrome (~1.5 seconds with all window frozen).

Adding a check within the bindings (just like the left mouse click checks) removes the need to repaint, and allows disabled elements to be skipped.
