### PR TITLE
Add listener to to update styles on programmatic checkbox changes

### DIFF
--- a/custom-form-elements.js
+++ b/custom-form-elements.js
@@ -126,6 +126,15 @@ Example:
 
             });
 
+            // Listen to checkbox change events and update the style accordingly
+            var cb = this;
+            if($(this).attr("type") === "checkbox") {
+                $(this).off("cfe-styled").on("change.cfe-styled", function() {
+                    var el = document.getElementById('cfe-' + cb.id);
+                    self.setState(el, (this.checked ? 2 : 0));
+                });
+            }
+
             this.bind();
         },
 


### PR DESCRIPTION
We hit an issue where styled checkbox elements don't reflect the actual underlying `<input type="checkbox">` elements' `checked` status when it is changed programmatically. Here's a patch that listens to the checkbox change events and changes the styles accordingly.
